### PR TITLE
add map primitive

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,7 +18,7 @@ for (root_path, dirs, files) in walkdir(source_path)
         # convert the source file to Markdown
         Literate.markdown(joinpath(root_path, file), output_dir; documenter = false)
         # TODO: make this respect nesting somehow!
-        push!(literate_pages, joinpath(output_dir, splitext(file)[1] * ".md"))
+        push!(literate_pages, joinpath(relpath(root_path, source_path), splitext(file)[1] * ".md"))
     end
 end
 

--- a/src/GeometryOps.jl
+++ b/src/GeometryOps.jl
@@ -5,6 +5,7 @@ using GeometryBasics
 
 const GI = GeoInterface
 
+include("primitives.jl")
 include("methods/signed_distance.jl")
 include("methods/signed_area.jl")
 include("methods/centroid.jl")

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -45,7 +45,7 @@ function apply(f, target::Type, trait, geom; crs=GI.crs(geom))::(GI.geointerface
     geoms = map(g -> apply(f, target, g), GI.getgeom(geom))
     if GI.is3d(geom)
         return GI.geointerface_geomtype(trait){true,false}(geoms; crs)
-    els
+    else
         return GI.geointerface_geomtype(trait){false,false}(geoms; crs)
     end
 end

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -25,7 +25,7 @@ apply(f, target::Type{<:GI.AbstractTrait}, geom; kw...) =
     apply(f, target, GI.trait(geom), geom; kw...)
 # Try to apply over iterables
 apply(f, target::Type, ::Nothing, iterable; kw...) =
-    map(x -> map(f, target, x), iterable; kw...)
+    map(x -> apply(f, target, x), iterable; kw...)
 # Rewrap feature collections
 function apply(f, target::Type, ::GI.FeatureCollectionTrait, fc; crs=GI.crs(fc))
     features = map(GI.getfeature(fc)) do feature
@@ -58,4 +58,3 @@ apply(f, target::Type, trait::GI.PointTrait, geom; crs=nothing) =
 apply(f, target::Type{GI.PointTrait}, trait::GI.PointTrait, geom; crs=nothing) = f(geom)
 apply(f, target::Type{GI.FeatureTrait}, ::GI.FeatureTrait, feature; crs=nothing) = f(feature)
 apply(f, target::Type{GI.FeatureCollectionTrait}, ::GI.FeatureCollectionTrait, fc; crs=nothing) = f(fc)
-

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -1,0 +1,82 @@
+"""
+    map(f, target::Type{<:AbstractTrait}, obj; crs)
+
+Reconstruct a geometry or feature using the function `f` on the `target` trait.
+
+`f(target_geom) => x` where `x` also has the `target` trait, or an equivalent.
+
+The result is an functionally similar geometry with values depending on `f`
+
+# Flipped point the order in any feature or geometry, or iterables of either:
+
+```juia
+import GeoInterface as GI
+import GeometryOps as GO
+geom = GI.Polygon([GI.LinearRing([(1, 2), (3, 4), (5, 6), (1, 2)]), 
+                   GI.LinearRing([(3, 4), (5, 6), (6, 7), (3, 4)])])
+flipped_geom = GO.map(GI.PointTrait, geom) do p
+    (GI.y(p), GI.x(p))
+end
+```
+
+Its also possible to change traits:
+
+```juia
+multipoints = GeometryOps.map(GI.LinearRingTrait, geom) do poly
+    GI.MultiPoint(GI.getpoint(poly))
+end
+```
+
+Or just return something else entirely, and get nested vectors:
+
+```julia
+multipoints = GeometryOps.map(GI.LinearRingTrait, geom) do poly
+    GI.npoint(poly)
+end
+```
+
+In which case a `PolygonTrait` objects will become `Vector{MultiPoint}`,
+as MultiPoint is no longer a subtrait of `Polygon`.
+"""
+function map end
+# Add dispatch argument for trait
+map(f, target::Type{<:GI.AbstractTrait}, geom; kw...) =
+    map(f, target, GI.trait(geom), geom; kw...)
+# Try to map over iterables
+map(f, target::Type, ::Nothing, iterable; kw...) =
+    Base.map(x -> Base.map(f, target, x), iterable; kw...)
+# Rewrap feature collections
+function map(f, target::Type, ::GI.FeatureCollectionTrait, fc; crs=GI.crs(fc))
+    features = Base.map(GI.getfeature(fc)) do feature
+        map(f, target, feature)
+    end 
+    return FeatureCollection(features; crs)
+end
+# Rewrap features
+function map(f, target::Type, ::GI.FeatureTrait, feature; crs=GI.crs(feature))
+    properties = GI.properties(feature)
+    geometry = map(f, target, geometry(feature); crs)
+    return Feature(geometry; properties, crs)
+end
+# Reconstruct nested geometries
+function map(f, target::Type, trait, geom; crs=GI.crs(geom))
+    # TODO handle zero length...
+    geoms = Base.map(g -> map(f, target, g), GI.getgeom(geom))
+    # Rewrap if the returned value is the right trait
+    if GI.trait(first(geoms)) isa GI.subtrait(GI.trait(geom))
+        return GI.geointerface_geomtype(trait)(geoms; crs)
+    else
+        # Or fall back to returning vectors
+        return geoms
+    end
+end
+# Apply f to the target geometry
+map(f, ::Type{Target}, ::Trait, geom; crs=nothing) where {Target,Trait<:Target} = f(geom)
+# Fail if we hit PointTrait without running `f`
+map(f, target::Type, trait::GI.PointTrait, geom; crs=nothing) =
+    throw(ArgumentError("target $target not found, but reached a `PointTrait` leaf"))
+# Specific cases to avoid method ambiguity
+map(f, target::Type{GI.PointTrait}, trait::GI.PointTrait, geom; crs=nothing) = f(geom)
+map(f, target::Type{GI.FeatureTrait}, ::GI.FeatureTrait, feature; crs=nothing) = f(feature)
+map(f, target::Type{GI.FeatureCollectionTrait}, ::GI.FeatureCollectionTrait, fc; crs=nothing) = f(fc)
+

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -44,6 +44,7 @@ function apply(f, target::Type, trait, geom; crs=GI.crs(geom))::(GI.geointerface
     # TODO handle zero length...
     geoms = map(g -> apply(f, target, g), GI.getgeom(geom))
     if GI.is3d(geom)
+        # The Boolean type parameters here indicate 3d-ness and measure coordinate presence respectively.
         return GI.geointerface_geomtype(trait){true,false}(geoms; crs)
     else
         return GI.geointerface_geomtype(trait){false,false}(geoms; crs)

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -6,7 +6,7 @@ import GeometryOps as GO
 geom = GI.Polygon([GI.LinearRing([(1, 2), (3, 4), (5, 6), (1, 2)]), 
                    GI.LinearRing([(3, 4), (5, 6), (6, 7), (3, 4)])])
 
-flipped_geom = GO.map(GI.PointTrait, geom) do p
+flipped_geom = GO.apply(GI.PointTrait, geom) do p
     (GI.y(p), GI.x(p))
 end
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -6,7 +6,7 @@ import GeometryOps as GO
 geom = GI.Polygon([GI.LinearRing([(1, 2), (3, 4), (5, 6), (1, 2)]), 
                    GI.LinearRing([(3, 4), (5, 6), (6, 7), (3, 4)])])
 
-@code_warntype GO.map(GI.PointTrait, geom) do p
+flipped_geom = GO.map(GI.PointTrait, geom) do p
     (GI.y(p), GI.x(p))
 end
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -1,0 +1,27 @@
+using Test
+
+import GeoInterface as GI
+import GeometryOps as GO
+
+geom = GI.Polygon([GI.LinearRing([(1, 2), (3, 4), (5, 6), (1, 2)]), 
+                   GI.LinearRing([(3, 4), (5, 6), (6, 7), (3, 4)])])
+
+flipped_geom = GO.map(GI.PointTrait, geom) do p
+    (GI.y(p), GI.x(p))
+end
+
+@test flipped_geom == GI.Polygon([GI.LinearRing([(2, 1), (4, 3), (6, 5), (2, 1)]), 
+                                  GI.LinearRing([(4, 3), (6, 5), (7, 6), (4, 3)])])
+
+multipoints = GeometryOps.map(GI.LinearRingTrait, geom) do poly
+    GI.MultiPoint(GI.getpoint(poly))
+end
+
+@test multipoints == [GI.MultiPoint([(1, 2), (3, 4), (5, 6), (1, 2)]), 
+                      GI.MultiPoint([(3, 4), (5, 6), (6, 7), (3, 4)])]
+
+lengths = GeometryOps.map(GI.LinearRingTrait, geom) do poly
+    GI.npoint(poly)
+end
+
+@test lengths == [4, 4]

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -6,22 +6,9 @@ import GeometryOps as GO
 geom = GI.Polygon([GI.LinearRing([(1, 2), (3, 4), (5, 6), (1, 2)]), 
                    GI.LinearRing([(3, 4), (5, 6), (6, 7), (3, 4)])])
 
-flipped_geom = GO.map(GI.PointTrait, geom) do p
+@code_warntype GO.map(GI.PointTrait, geom) do p
     (GI.y(p), GI.x(p))
 end
 
 @test flipped_geom == GI.Polygon([GI.LinearRing([(2, 1), (4, 3), (6, 5), (2, 1)]), 
                                   GI.LinearRing([(4, 3), (6, 5), (7, 6), (4, 3)])])
-
-multipoints = GeometryOps.map(GI.LinearRingTrait, geom) do poly
-    GI.MultiPoint(GI.getpoint(poly))
-end
-
-@test multipoints == [GI.MultiPoint([(1, 2), (3, 4), (5, 6), (1, 2)]), 
-                      GI.MultiPoint([(3, 4), (5, 6), (6, 7), (3, 4)])]
-
-lengths = GeometryOps.map(GI.LinearRingTrait, geom) do poly
-    GI.npoint(poly)
-end
-
-@test lengths == [4, 4]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,5 +8,6 @@ const GI = GeoInterface
 const AG = ArchGDAL
 
 @testset "GeometryOps.jl" begin
-    @testset "Signed Area" include("methods/signed_area.jl")
+    @testset "Primitives" begin include("primitives.jl") end
+    @testset "Signed Area" begin include("methods/signed_area.jl") end
 end


### PR DESCRIPTION
This is the `map` primitive I was talking about on slack. It runs a function over some trait level in a Geometry or in iterators of geometries. Unfortunately Base gives up on recursion so the stability isn't great.

Maybe `map` is too overloaded with Base, it also means we have to qualify `Base.map` everywhere here. 

But something short would be nice.  other ideas?

`reconstruct` is something I use in other packages for a similar thing, but its a bit long?

