### PR TITLE
Thread for transformations like reproject, simplify, etc

### DIFF
--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -24,7 +24,7 @@ flipped_geom = GO.apply(GI.PointTrait, geom) do p
     (GI.y(p), GI.x(p))
 end
 """
-function apply(f, ::Type{Target}, geom; calc_extent=nothing, crs=nothing, kw...) where Target 
+function apply(f, ::Type{Target}, geom; calc_extent=nothing, kw...) where Target 
     # Catch the type instability here in the outer method
     # so false is nothing::Nothing and true is true::Bool
     # we can think of a nicer way to do this later...

--- a/src/transformations/extent.jl
+++ b/src/transformations/extent.jl
@@ -6,7 +6,7 @@ calculating and adding an `Extents.Extent` to all objects.
 
 This can improve performance when extents need to be checked multiple times.
 """
-embed_extent(x) = apply(extent_applicator, AbstractTrait, x)
+embed_extent(x; kw...) = apply(AbstractTrait, x; kw...)
 
 extent_applicator(x) = extent_applicator(trait(x), x)
 extent_applicator(::Nothing, xs::AbstractArray) = embed_extent.(xs)

--- a/src/transformations/reproject.jl
+++ b/src/transformations/reproject.jl
@@ -65,20 +65,12 @@ function reproject(geom, source_crs, target_crs;
 end
 function reproject(geom, transform::Proj.Transformation; time=Inf, target_crs=nothing, kw...)
     if _is3d(geom)
-        return apply(Union{GI.LineStringTrait,GI.LinearRingTrait,GI.MultiPointTrait}, geom; crs=target_crs, kw...) do geom
-            points = map(GI.getpoint(geom)) do p
-                transform(GI.x(p), GI.y(p), GI.z(p))
-            end
-            extent = Extents.Extent(X=extrema(first, points), Y=extrema(p -> p[2], points), Z=extrema(last, points))
-            rebuild(geom, points; extent, crs=target_crs)
+        return apply(PointTrait, geom; crs=target_crs, kw...) do p
+            transform(GI.x(p), GI.y(p), GI.z(p))
         end
     else
-        return apply(Union{GI.LineStringTrait,GI.LinearRingTrait,GI.MultiPointTrait}, geom; crs=target_crs, kw...) do geom
-            points = map(GI.getpoint(geom)) do p
-                transform(GI.x(p), GI.y(p))
-            end
-            extent = Extents.Extent(X=extrema(first, points), Y=extrema(last, points))
-            rebuild(geom, points; extent, crs=target_crs)
+        return apply(PointTrait, geom; crs=target_crs, kw...) do p
+            transform(GI.x(p), GI.y(p))
         end
     end
 end

--- a/src/transformations/reproject.jl
+++ b/src/transformations/reproject.jl
@@ -38,8 +38,18 @@ function reproject(geom;
     source_crs=nothing, target_crs=nothing, transform=nothing, kw...
 )
     if isnothing(transform)
-        source_crs = isnothing(source_crs) ? GeoInterface.crs(geom) : source_crs
+        if isnothing(source_crs) 
+            source_crs = if GI.trait(geom) isa Nothing && geom isa AbstractArray
+                GeoInterface.crs(first(geom))
+            else
+                GeoInterface.crs(geom)
+            end
+        end
+
+        # If its still nothing, error
         isnothing(source_crs) && throw(ArgumentError("geom has no crs attatched. Pass a `source_crs` keyword"))
+
+        # Otherwise reproject
         reproject(geom, source_crs, target_crs; kw...)
     else
         reproject(geom, transform; kw...)

--- a/src/transformations/simplify.jl
+++ b/src/transformations/simplify.jl
@@ -99,7 +99,8 @@ GI.npoint(simple)
 6
 ```
 """
-simplify(data; calc_extent=false, kw...) = _simplify(DouglasPeucker(; kw...), data; calc_extent)
+simplify(data; calc_extent=false, threaded=false, kw...) =
+    _simplify(DouglasPeucker(; kw...), data; calc_extent, threaded)
 simplify(alg::SimplifyAlg, data; kw...) = _simplify(alg, data; kw...)
 
 function _simplify(alg::SimplifyAlg, data; kw...)

--- a/test/transformations/reproject.jl
+++ b/test/transformations/reproject.jl
@@ -38,5 +38,8 @@ import Proj
     # Embedded crs check
     @test GI.crs(multipolygon3857) == EPSG(3857)
     @test GI.crs(multipolygon4326) == EPSG(4326)
+
+    # Run it threaded over 100 replicates
+    GO.reproject([multipolygon3857 for _ in 1:100]; target_crs=EPSG(4326), threaded=true, calc_extent=true)
 end
 

--- a/test/transformations/simplify.jl
+++ b/test/transformations/simplify.jl
@@ -4,15 +4,17 @@ import GeoInterface as GI
 import GeometryOps as GO
 import GeoJSON
 
-# Unncomment when JSON3 bumps a patch version
-# @testset "simplify" begin
-#     datadir = realpath(joinpath(dirname(pathof(GO)), "../test/data"))
-#     fc = GeoJSON.read(joinpath(datadir, "simplify.geojson"))
-#     fc2 = GeoJSON.read(joinpath(datadir, "simplify2.geojson"))
+@testset "simplify" begin
+    datadir = realpath(joinpath(dirname(pathof(GO)), "../test/data"))
+    fc = GeoJSON.read(joinpath(datadir, "simplify.geojson"))
+    fc2 = GeoJSON.read(joinpath(datadir, "simplify2.geojson"))
+    T = GO.RadialDistance
+    fcs = [fc for i in 1:100]
 
-#     for T in (GO.RadialDistance, GO.VisvalingamWhyatt, GO.DouglasPeucker)
-#         @test length(collect(GO.flatten(GI.PointTrait, GO.simplify(T(number=10), fc)))) == 10
-#         @test length(collect(GO.flatten(GI.PointTrait, GO.simplify(T(ratio=0.5), fc)))) == 39 # Half of 78
-#         GO.simplify(T(tol=0.001), fc)
-#     end
-# end
+    for T in (GO.RadialDistance, GO.VisvalingamWhyatt, GO.DouglasPeucker)
+        @test length(collect(GO.flatten(GI.PointTrait, GO.simplify(T(number=10), fc)))) == 10
+        @test length(collect(GO.flatten(GI.PointTrait, GO.simplify(T(ratio=0.5), fc)))) == 39 # Half of 78
+        GO.simplify(T(tol=0.001), fc; threaded=true, calc_extent=true)
+        GO.simplify(T(tol=0.001), fcs; threaded=true, calc_extent=true)
+    end
+end


### PR DESCRIPTION
Add optional threading to everything that uses `apply`.

Threaded tasks will be used at the outermost level of the object passed in, over a vector of geometries, features in a feature collection, or e.g. polygons in a multipolygon.

See #23