### PR TITLE
add transform method for coordinate transformations

### DIFF
--- a/src/GeometryOps.jl
+++ b/src/GeometryOps.jl
@@ -7,6 +7,7 @@ using GeometryBasics
 import Proj
 using LinearAlgebra
 import ExactPredicates
+import Proj.CoordinateTransformations.StaticArrays
 
 using GeoInterface.Extents: Extents
 
@@ -38,5 +39,6 @@ include("transformations/flip.jl")
 include("transformations/simplify.jl")
 include("transformations/reproject.jl")
 include("transformations/tuples.jl")
+include("transformations/transform.jl")
 
 end

--- a/src/transformations/transform.jl
+++ b/src/transformations/transform.jl
@@ -42,11 +42,11 @@ ctor{2, Int64}[[2, 1], [4, 3], [6, 5], [2, 1]], nothing, nothing), GeoInterface.
 function transform(f, geom; kw...) 
     if _is3d(geom)
         return apply(PointTrait, geom; kw...) do p
-            f(StaticArrays.SVector{3}((GI.y(p), GI.x(p), GI.z(p))))
+            f(StaticArrays.SVector{3}((GI.x(p), GI.y(p), GI.z(p))))
         end
     else
         return apply(PointTrait, geom; kw...) do p
-            f(StaticArrays.SVector{2}((GI.y(p), GI.x(p))))
+            f(StaticArrays.SVector{2}((GI.x(p), GI.y(p))))
         end
     end
 end

--- a/src/transformations/transform.jl
+++ b/src/transformations/transform.jl
@@ -1,0 +1,52 @@
+
+"""
+    transform(f, obj)
+
+Apply a function `f` to all the points in `obj`.
+
+Points will be passed to `f` as an `SVector` to allow
+using CoordinateTransformations.jl and Rotations.jl 
+without hassle.
+
+`SVector` is also a valid GeoInterface.jl point, so will
+work in all GeoInterface.jl methods.
+
+## Example
+
+```julia
+julia> geom = GI.Polygon([GI.LinearRing([(1, 2), (3, 4), (5, 6), (1, 2)]), GI.LinearRing([(3, 4), (5, 6), (6, 7), (3, 4)])]);
+
+julia> f = CoordinateTransformations.Translation(3.5, 1.5)
+Translation(3.5, 1.5)
+
+julia> GO.transform(f, geom)
+GeoInterface.Wrappers.Polygon{false, false, Vector{GeoInterface.Wrappers.LinearRing{false, false, Vector{StaticArraysCore.SVector{2, Float64}}, Nothing, Nothing}}, Nothing, Nothing}(GeoInterface.Wrappers.Linea
+rRing{false, false, Vector{StaticArraysCore.SVector{2, Float64}}, Nothing, Nothing}[GeoInterface.Wrappers.LinearRing{false, false, Vector{StaticArraysCore.SVector{2, Float64}}, Nothing, Nothing}(StaticArraysCo
+re.SVector{2, Float64}[[5.5, 2.5], [7.5, 4.5], [9.5, 6.5], [5.5, 2.5]], nothing, nothing), GeoInterface.Wrappers.LinearRing{false, false, Vector{StaticArraysCore.SVector{2, Float64}}, Nothing, Nothing}(StaticA
+rraysCore.SVector{2, Float64}[[7.5, 4.5], [9.5, 6.5], [10.5, 7.5], [7.5, 4.5]], nothing, nothing)], nothing, nothing)
+```
+
+With Rotations.jl you need to actuall multiply the Rotation
+by the `SVector` point, which is easy using an anonymous function.
+
+```julia
+julia> using Rotations
+
+julia> GO.transform(p -> one(RotMatrix{2}) * p, geom)
+GeoInterface.Wrappers.Polygon{false, false, Vector{GeoInterface.Wrappers.LinearRing{false, false, Vector{StaticArraysCore.SVector{2, Int64}}, Nothing, Nothing}}, Nothing, Nothing}(GeoInterface.Wrappers.LinearR
+ing{false, false, Vector{StaticArraysCore.SVector{2, Int64}}, Nothing, Nothing}[GeoInterface.Wrappers.LinearRing{false, false, Vector{StaticArraysCore.SVector{2, Int64}}, Nothing, Nothing}(StaticArraysCore.SVe
+ctor{2, Int64}[[2, 1], [4, 3], [6, 5], [2, 1]], nothing, nothing), GeoInterface.Wrappers.LinearRing{false, false, Vector{StaticArraysCore.SVector{2, Int64}}, Nothing, Nothing}(StaticArraysCore.SVector{2, Int64
+}[[4, 3], [6, 5], [7, 6], [4, 3]], nothing, nothing)], nothing, nothing)
+```
+"""
+function transform(f, geom; kw...) 
+    if _is3d(geom)
+        return apply(PointTrait, geom; kw...) do p
+            f(StaticArrays.SVector{3}((GI.y(p), GI.x(p), GI.z(p))))
+        end
+    else
+        return apply(PointTrait, geom; kw...) do p
+            f(StaticArrays.SVector{2}((GI.y(p), GI.x(p))))
+        end
+    end
+end

--- a/src/transformations/transform.jl
+++ b/src/transformations/transform.jl
@@ -14,6 +14,10 @@ work in all GeoInterface.jl methods.
 ## Example
 
 ```julia
+julia> import GeoInterface as GI
+
+julia> import GeometryOps as GO
+
 julia> geom = GI.Polygon([GI.LinearRing([(1, 2), (3, 4), (5, 6), (1, 2)]), GI.LinearRing([(3, 4), (5, 6), (6, 7), (3, 4)])]);
 
 julia> f = CoordinateTransformations.Translation(3.5, 1.5)
@@ -22,8 +26,8 @@ Translation(3.5, 1.5)
 julia> GO.transform(f, geom)
 GeoInterface.Wrappers.Polygon{false, false, Vector{GeoInterface.Wrappers.LinearRing{false, false, Vector{StaticArraysCore.SVector{2, Float64}}, Nothing, Nothing}}, Nothing, Nothing}(GeoInterface.Wrappers.Linea
 rRing{false, false, Vector{StaticArraysCore.SVector{2, Float64}}, Nothing, Nothing}[GeoInterface.Wrappers.LinearRing{false, false, Vector{StaticArraysCore.SVector{2, Float64}}, Nothing, Nothing}(StaticArraysCo
-re.SVector{2, Float64}[[5.5, 2.5], [7.5, 4.5], [9.5, 6.5], [5.5, 2.5]], nothing, nothing), GeoInterface.Wrappers.LinearRing{false, false, Vector{StaticArraysCore.SVector{2, Float64}}, Nothing, Nothing}(StaticA
-rraysCore.SVector{2, Float64}[[7.5, 4.5], [9.5, 6.5], [10.5, 7.5], [7.5, 4.5]], nothing, nothing)], nothing, nothing)
+re.SVector{2, Float64}[[4.5, 3.5], [6.5, 5.5], [8.5, 7.5], [4.5, 3.5]], nothing, nothing), GeoInterface.Wrappers.LinearRing{false, false, Vector{StaticArraysCore.SVector{2, Float64}}, Nothing, Nothing}(StaticA
+rraysCore.SVector{2, Float64}[[6.5, 5.5], [8.5, 7.5], [9.5, 8.5], [6.5, 5.5]], nothing, nothing)], nothing, nothing)
 ```
 
 With Rotations.jl you need to actuall multiply the Rotation

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,4 +28,5 @@ const GO = GeometryOps
     @testset "Reproject" begin include("transformations/reproject.jl") end
     @testset "Flip" begin include("transformations/flip.jl") end
     @testset "Simplify" begin include("transformations/simplify.jl") end
+    @testset "Transform" begin include("transformations/transform.jl") end
 end

--- a/test/transformations/transform.jl
+++ b/test/transformations/transform.jl
@@ -1,0 +1,19 @@
+using Test
+ 
+import GeoInterface as GI
+import GeometryOps as GO
+using GeometryOps.Proj.CoordinateTransformations
+using Rotations
+
+@testset "transform" begin
+    geom = GI.Polygon([GI.LinearRing([(1, 2), (3, 4), (5, 6), (1, 2)]), 
+                       GI.LinearRing([(3, 4), (5, 6), (6, 7), (3, 4)])])
+    translated = GI.Polygon([GI.LinearRing([[5.5, 2.5], [7.5, 4.5], [9.5, 6.5], [5.5, 2.5]]), GI.LinearRing([[7.5, 4.5], [9.5, 6.5], [10.5, 7.5], [7.5, 4.5]])])
+    f = CoordinateTransformations.Translation(3.5, 1.5)
+    @test GO.transform(f, geom) == translated
+    GO.transform(p -> one(RotMatrix{2}) * p, geom)
+    == translated
+    
+
+end
+

--- a/test/transformations/transform.jl
+++ b/test/transformations/transform.jl
@@ -3,7 +3,6 @@ using Test
 import GeoInterface as GI
 import GeometryOps as GO
 using GeometryOps.Proj.CoordinateTransformations
-using Rotations
 
 @testset "transform" begin
     geom = GI.Polygon([GI.LinearRing([(1, 2), (3, 4), (5, 6), (1, 2)]), 
@@ -11,9 +10,4 @@ using Rotations
     translated = GI.Polygon([GI.LinearRing([[5.5, 2.5], [7.5, 4.5], [9.5, 6.5], [5.5, 2.5]]), GI.LinearRing([[7.5, 4.5], [9.5, 6.5], [10.5, 7.5], [7.5, 4.5]])])
     f = CoordinateTransformations.Translation(3.5, 1.5)
     @test GO.transform(f, geom) == translated
-    GO.transform(p -> one(RotMatrix{2}) * p, geom)
-    == translated
-    
-
 end
-

--- a/test/transformations/transform.jl
+++ b/test/transformations/transform.jl
@@ -7,7 +7,8 @@ using GeometryOps.Proj.CoordinateTransformations
 @testset "transform" begin
     geom = GI.Polygon([GI.LinearRing([(1, 2), (3, 4), (5, 6), (1, 2)]), 
                        GI.LinearRing([(3, 4), (5, 6), (6, 7), (3, 4)])])
-    translated = GI.Polygon([GI.LinearRing([[5.5, 2.5], [7.5, 4.5], [9.5, 6.5], [5.5, 2.5]]), GI.LinearRing([[7.5, 4.5], [9.5, 6.5], [10.5, 7.5], [7.5, 4.5]])])
+    translated = GI.Polygon([GI.LinearRing([[4.5, 3.5], [6.5, 5.5], [8.5, 7.5], [4.5, 3.5]]), 
+                             GI.LinearRing([[6.5, 5.5], [8.5, 7.5], [9.5, 8.5], [6.5, 5.5]])])
     f = CoordinateTransformations.Translation(3.5, 1.5)
     @test GO.transform(f, geom) == translated
 end


### PR DESCRIPTION
Closes #34 

This PR adds a simple `transform` function that converts points to `SVector` on the fly, transforms them using some transformation from CoordinateTransformations.jl or Rotations.jl, and rebuilds the object around the new points.

Like a few of the other transformation methods, this function is a pretty basic use of `apply`. But I think it may not seem obvious to people that you can do this so easily so it's worth having.