### PR TITLE
Remove more type instability (especially in `applyreduce`)

### DIFF
--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -260,21 +260,21 @@ If `threaded==true` threads will be used over arrays and iterables,
 feature collections and nested geometries.
 """
 @inline function applyreduce(
-    f::F, op::OT, target, geom; threaded=false, init=nothing
-) where {F, OT}
+    f::F, op::O, target, geom; threaded=false, init=nothing
+) where {F, O}
     threaded = _booltype(threaded)
     _applyreduce(f, op, TraitTarget(target), geom; threaded, init)
 end
 
-@inline _applyreduce(f::F, op::OT, target, geom; threaded, init) where {F, OT} =
+@inline _applyreduce(f::F, op::O, target, geom; threaded, init) where {F, O} =
     _applyreduce(f, op, target, GI.trait(geom), geom; threaded, init)
 # Maybe use threads recucing over arrays
-@inline function _applyreduce(f::F, op::OT, target, ::Nothing, A::AbstractArray; threaded, init) where {F, OT}
+@inline function _applyreduce(f::F, op::O, target, ::Nothing, A::AbstractArray; threaded, init) where {F, O}
     applyreduce_array(i) = _applyreduce(f, op, target, A[i]; threaded=_False(), init)
     _mapreducetasks(applyreduce_array, op, eachindex(A), threaded; init)
 end
 # Try to applyreduce over iterables
-@inline function _applyreduce(f::F, op::OT, target, ::Nothing, iterable; threaded, init) where {F, OT}
+@inline function _applyreduce(f::F, op::O, target, ::Nothing, iterable; threaded, init) where {F, O}
     applyreduce_iterable(i) = _applyreduce(f, op, target, x; threaded=_False(), init)
     if threaded # Try to `collect` and reduce over the vector with threads
         _applyreduce(f, op, target, collect(iterable); threaded, init)
@@ -284,27 +284,27 @@ end
     end
 end
 # Maybe use threads reducing over features of feature collections
-@inline function _applyreduce(f::F, op::OT, target, ::GI.FeatureCollectionTrait, fc; threaded, init) where {F, OT}
+@inline function _applyreduce(f::F, op::O, target, ::GI.FeatureCollectionTrait, fc; threaded, init) where {F, O}
     applyreduce_fc(i) = _applyreduce(f, op, target, GI.getfeature(fc, i); threaded=_False(), init)
     _mapreducetasks(applyreduce_fc, op, 1:GI.nfeature(fc), threaded; init)
 end
 # Features just applyreduce to their geometry
-@inline _applyreduce(f::F, op::OT, target, ::GI.FeatureTrait, feature; threaded, init) where {F, OT} =
+@inline _applyreduce(f::F, op::O, target, ::GI.FeatureTrait, feature; threaded, init) where {F, O} =
     _applyreduce(f, op, target, GI.geometry(feature); threaded, init)
 # Maybe use threads over components of nested geometries
-@inline function _applyreduce(f::F, op::OT, target, trait, geom; threaded, init) where {F, OT}
+@inline function _applyreduce(f::F, op::O, target, trait, geom; threaded, init) where {F, O}
     applyreduce_geom(i) = _applyreduce(f, op, target, GI.getgeom(geom, i); threaded=_False(), init)
     _mapreducetasks(applyreduce_geom, op, 1:GI.ngeom(geom), threaded; init)
 end
 # Don't thread over points it won't pay off
 @inline function _applyreduce(
-    f::F, op::OT, target, trait::Union{GI.LinearRing,GI.LineString,GI.MultiPoint}, geom;
+    f::F, op::O, target, trait::Union{GI.LinearRing,GI.LineString,GI.MultiPoint}, geom;
     threaded, init
-) where {F, OT}
+) where {F, O}
     _applyreduce(f, op, target, GI.getgeom(geom); threaded=_False(), init)
 end
 # Apply f to the target
-@inline function _applyreduce(f::F, op::OT, ::TraitTarget{Target}, ::Trait, x; kw...) where {F,OT,Target,Trait<:Target} 
+@inline function _applyreduce(f::F, op::O, ::TraitTarget{Target}, ::Trait, x; kw...) where {F,O,Target,Trait<:Target} 
     f(x)
 end
 # Fail if we hit PointTrait
@@ -315,7 +315,7 @@ for T in (
     GI.PointTrait, GI.LinearRing, GI.LineString, 
     GI.MultiPoint, GI.FeatureTrait, GI.FeatureCollectionTrait
 )
-    @eval _applyreduce(f::F, op::OT, ::TraitTarget{<:$T}, trait::$T, x; kw...) where {F, OT} = f(x)
+    @eval _applyreduce(f::F, op::O, ::TraitTarget{<:$T}, trait::$T, x; kw...) where {F, O} = f(x)
 end
 
 """

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -260,21 +260,21 @@ If `threaded==true` threads will be used over arrays and iterables,
 feature collections and nested geometries.
 """
 @inline function applyreduce(
-    f::F, op, target, geom; threaded=false, init=nothing
-) where F
+    f::F, op::OT, target, geom; threaded=false, init=nothing
+) where {F, OT}
     threaded = _booltype(threaded)
     _applyreduce(f, op, TraitTarget(target), geom; threaded, init)
 end
 
-@inline _applyreduce(f::F, op, target, geom; threaded, init) where F =
+@inline _applyreduce(f::F, op::OT, target, geom; threaded, init) where {F, OT} =
     _applyreduce(f, op, target, GI.trait(geom), geom; threaded, init)
 # Maybe use threads recucing over arrays
-@inline function _applyreduce(f::F, op, target, ::Nothing, A::AbstractArray; threaded, init) where F
+@inline function _applyreduce(f::F, op::OT, target, ::Nothing, A::AbstractArray; threaded, init) where {F, OT}
     applyreduce_array(i) = _applyreduce(f, op, target, A[i]; threaded=_False(), init)
     _mapreducetasks(applyreduce_array, op, eachindex(A), threaded; init)
 end
 # Try to applyreduce over iterables
-@inline function _applyreduce(f::F, op, target, ::Nothing, iterable; threaded, init) where F
+@inline function _applyreduce(f::F, op::OT, target, ::Nothing, iterable; threaded, init) where {F, OT}
     applyreduce_iterable(i) = _applyreduce(f, op, target, x; threaded=_False(), init)
     if threaded # Try to `collect` and reduce over the vector with threads
         _applyreduce(f, op, target, collect(iterable); threaded, init)
@@ -284,27 +284,27 @@ end
     end
 end
 # Maybe use threads reducing over features of feature collections
-@inline function _applyreduce(f::F, op, target, ::GI.FeatureCollectionTrait, fc; threaded, init) where F
+@inline function _applyreduce(f::F, op::OT, target, ::GI.FeatureCollectionTrait, fc; threaded, init) where {F, OT}
     applyreduce_fc(i) = _applyreduce(f, op, target, GI.getfeature(fc, i); threaded=_False(), init)
     _mapreducetasks(applyreduce_fc, op, 1:GI.nfeature(fc), threaded; init)
 end
 # Features just applyreduce to their geometry
-@inline _applyreduce(f::F, op, target, ::GI.FeatureTrait, feature; threaded, init) where F =
+@inline _applyreduce(f::F, op::OT, target, ::GI.FeatureTrait, feature; threaded, init) where {F, OT} =
     _applyreduce(f, op, target, GI.geometry(feature); threaded, init)
 # Maybe use threads over components of nested geometries
-@inline function _applyreduce(f::F, op, target, trait, geom; threaded, init) where F
+@inline function _applyreduce(f::F, op::OT, target, trait, geom; threaded, init) where {F, OT}
     applyreduce_geom(i) = _applyreduce(f, op, target, GI.getgeom(geom, i); threaded=_False(), init)
     _mapreducetasks(applyreduce_geom, op, 1:GI.ngeom(geom), threaded; init)
 end
 # Don't thread over points it won't pay off
 @inline function _applyreduce(
-    f::F, op, target, trait::Union{GI.LinearRing,GI.LineString,GI.MultiPoint}, geom;
+    f::F, op::OT, target, trait::Union{GI.LinearRing,GI.LineString,GI.MultiPoint}, geom;
     threaded, init
-) where F
+) where {F, OT}
     _applyreduce(f, op, target, GI.getgeom(geom); threaded=_False(), init)
 end
 # Apply f to the target
-@inline function _applyreduce(f::F, op, ::TraitTarget{Target}, ::Trait, x; kw...) where {F,Target,Trait<:Target} 
+@inline function _applyreduce(f::F, op::OT, ::TraitTarget{Target}, ::Trait, x; kw...) where {F,OT,Target,Trait<:Target} 
     f(x)
 end
 # Fail if we hit PointTrait
@@ -315,7 +315,7 @@ for T in (
     GI.PointTrait, GI.LinearRing, GI.LineString, 
     GI.MultiPoint, GI.FeatureTrait, GI.FeatureCollectionTrait
 )
-    @eval _applyreduce(f::F, op, ::TraitTarget{<:$T}, trait::$T, x; kw...) where F = f(x)
+    @eval _applyreduce(f::F, op::OT, ::TraitTarget{<:$T}, trait::$T, x; kw...) where {F, OT} = f(x)
 end
 
 """

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -20,7 +20,7 @@ struct _True <: BoolsAsTypes end
 struct _False <: BoolsAsTypes end
 
 @inline _booltype(x::Bool)::BoolsAsTypes = x ? _True() : _False()
-@inline _booltype(x::BoolsAsTypes) = x
+@inline _booltype(x::BoolsAsTypes)::BoolsAsTypes = x
 
 """
     TraitTarget{T}


### PR DESCRIPTION
This solves the `centroid` and `area` type instabilities.  Should be ready to go!

```julia

julia> centroid_ag_pre = @be GO.centroid($water1)
Benchmark: 1079 samples with 1 evaluation
min    70.583 μs (319 allocs: 5.281 KiB)
median 76.000 μs (319 allocs: 5.281 KiB)
mean   77.389 μs (319 allocs: 5.281 KiB)
max    168.667 μs (319 allocs: 5.281 KiB)

julia> centroid_go_pre = @be GO.centroid($(GO.tuples(water1)))
Benchmark: 3593 samples with 4 evaluations
min    6.229 μs (18 allocs: 504 bytes)
median 6.281 μs (18 allocs: 504 bytes)
mean   6.321 μs (18 allocs: 504 bytes)
max    17.104 μs (18 allocs: 504 bytes)

julia> Revise.retry()

julia> centroid_ag_post = @be GO.centroid($water1)
Benchmark: 1283 samples with 1 evaluation
min    66.042 μs (319 allocs: 5.281 KiB)
median 71.167 μs (319 allocs: 5.281 KiB)
mean   72.505 μs (319 allocs: 5.281 KiB)
max    166.666 μs (319 allocs: 5.281 KiB)

julia> centroid_go_post = @be GO.centroid($(GO.tuples(water1)))
Benchmark: 3718 samples with 4 evaluations
min    5.989 μs (18 allocs: 504 bytes)
median 6.031 μs (18 allocs: 504 bytes)
mean   6.110 μs (18 allocs: 504 bytes)
max    17.156 μs (18 allocs: 504 bytes)
```
so this shaves off a small but noticeable amount of time, around 3% for native Julia geometries and 7% for ArchGDAL coming from C.