### PR TITLE
convert to string rather than CRS in `reproject`

### DIFF
--- a/ext/GeometryOpsProjExt/reproject.jl
+++ b/ext/GeometryOpsProjExt/reproject.jl
@@ -25,7 +25,7 @@ end
 function reproject(geom, source_crs, target_crs;
     time=Inf,
     always_xy=true,
-    transform=Proj.Transformation(Proj.CRS(source_crs), Proj.CRS(target_crs); always_xy),
+    transform=Proj.Transformation(convert(String, source_crs), convert(String, target_crs); always_xy),
     kw...
 )
     reproject(geom, transform; time, target_crs, kw...)

--- a/ext/GeometryOpsProjExt/reproject.jl
+++ b/ext/GeometryOpsProjExt/reproject.jl
@@ -25,9 +25,16 @@ end
 function reproject(geom, source_crs, target_crs;
     time=Inf,
     always_xy=true,
-    transform=Proj.Transformation(convert(String, source_crs), convert(String, target_crs); always_xy),
+    transform=nothing,
     kw...
 )
+    transform = if isnothing(transform) 
+        s = source_crs isa Proj.CRS ? source_crs : convert(String, source_crs)
+        t = target_crs isa Proj.CRS ? target_crs : convert(String, target_crs)
+        Proj.Transformation(s, t; always_xy)
+    else
+        transform
+    end
     reproject(geom, transform; time, target_crs, kw...)
 end
 function reproject(geom, transform::Proj.Transformation; time=Inf, target_crs=nothing, kw...)

--- a/test/transformations/reproject.jl
+++ b/test/transformations/reproject.jl
@@ -41,5 +41,39 @@ import Proj
 
     # Run it threaded over 100 replicates
     GO.reproject([multipolygon3857 for _ in 1:100]; target_crs=EPSG(4326), threaded=true, calc_extent=true)
+
+    utm32_wkt = """
+    PROJCS["WGS 84 / UTM zone 32N",
+        GEOGCS["WGS 84",
+            DATUM["WGS_1984",
+                SPHEROID["WGS 84",6378137,298.257223563,
+                    AUTHORITY["EPSG","7030"]],
+                AUTHORITY["EPSG","6326"]],
+            PRIMEM["Greenwich",0,
+                AUTHORITY["EPSG","8901"]],
+            UNIT["degree",0.0174532925199433,
+                AUTHORITY["EPSG","9122"]],
+            AUTHORITY["EPSG","4326"]],
+        PROJECTION["Transverse_Mercator"],
+        PARAMETER["latitude_of_origin",0],
+        PARAMETER["central_meridian",9],
+        PARAMETER["scale_factor",0.9996],
+        PARAMETER["false_easting",500000],
+        PARAMETER["false_northing",0],
+        UNIT["metre",1,
+            AUTHORITY["EPSG","9001"]],
+        AXIS["Easting",EAST],
+        AXIS["Northing",NORTH],
+        AUTHORITY["EPSG","32632"]]
+    """
+
+    @test GO.reproject(multipolygon4326; source_crs="epsg:4326", target_crs="+proj=utm +zone=32 +datum=WGS84") ==
+        GO.reproject(multipolygon4326; source_crs=EPSG(4326), target_crs=ProjString("+proj=utm +zone=32 +datum=WGS84")) ==
+        GO.reproject(multipolygon4326; target_crs=EPSG(32632)) ==
+        GO.reproject(multipolygon4326; target_crs="epsg:32632") ==
+        GO.reproject(multipolygon4326; target_crs=utm32_wkt)
+
+    GO.reproject(multipolygon4326; target_crs=ProjString("+proj=moll"))
+
 end
 


### PR DESCRIPTION
Turns out it works just  converting everything to `String` rather than `Proj.CRS`.

This should be fixed in proj, but this seems fine for now.